### PR TITLE
Correct iteration logic on announcements

### DIFF
--- a/app/Http/Composers/SiteComposer.php
+++ b/app/Http/Composers/SiteComposer.php
@@ -3,7 +3,7 @@
 namespace App\Http\Composers;
 
 use Facades\App\Repositories\AOD\DivisionRepository;
-use App\Support\RssReader;
+use Facades\App\Support\RssReader;
 use Facades\App\Support\Twitter;
 use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Http;
@@ -78,9 +78,13 @@ class SiteComposer
             return simplexml_load_file(storage_path('testing/announcements.xml'))->channel;
         }
 
-        return (new RssReader())->setPath(
-            config('services.aod.announcements_rss_feed')
-        )->getItems();
+        $feed = RssReader::setPath(config('services.aod.announcements_rss_feed'));
+
+        if (!$feed) {
+            return [];
+        }
+
+        return $feed->getItems();
     }
 
     /**

--- a/app/Support/RssReader.php
+++ b/app/Support/RssReader.php
@@ -17,7 +17,12 @@ class RssReader
             return false;
         }
 
-        $simpleXML = new SimpleXMLElement($data);
+        try {
+            $simpleXML = new SimpleXMLElement($data);
+        } catch (\Exception $exception) {
+            \Log::error($exception->getMessage());
+            return false;
+        }
 
         if (!property_exists($simpleXML, 'channel')) {
             return false;

--- a/config/services.php
+++ b/config/services.php
@@ -25,6 +25,7 @@ return [
         'announcements_rss_feed' => env('ANNOUNCEMENTS_RSS_FEED'),
         'tracker_url' => env('TRACKER_URL', '//tracker.clanaod.net'),
         'twitter_rss_feed' => env('TWITTER_RSS_FEED'),
+        'max_announcements' => env('MAX_FOOTER_ANNOUNCEMENTS', 4),
     ],
 
     'twitter' => [

--- a/resources/views/partials/announcements.blade.php
+++ b/resources/views/partials/announcements.blade.php
@@ -1,15 +1,18 @@
 <div class="announcements footer-section">
     <h1>Clan Announcements</h1>
-    @if($aod_announcements->count())
+    @if($aod_announcements)
         <ul>
-            @for ($i = 0;$i < 4;$i ++)
+            @foreach ($aod_announcements->item as $announcement)
                 <li>
-                    <a href="{{ $aod_announcements->item[$i]->guid }}">
-                        {{ $aod_announcements->item[$i]->title }}
+                    <a href="{{ $announcement->guid }}">
+                        {{ $announcement->title }}
                     </a>
-                    <br/>Posted {{ $aod_announcements->item[$i]->pubDate }}
+                    <br/>Posted {{ $announcement->pubDate }}
                 </li>
-            @endfor
+                @if ($loop->iteration >= config('services.aod.max_announcements'))
+                    @break
+                @endif
+            @endforeach
         </ul>
     @else
         <div style="width: 90%; line-height: 1.5em">

--- a/tests/Feature/HomePageTest.php
+++ b/tests/Feature/HomePageTest.php
@@ -61,4 +61,16 @@ class HomePageTest extends TestCase
 
         $data->assertOk();
     }
+
+    /** @test */
+    public function home_page_returns_200_ok_if_rss_announcements_lookup_fails()
+    {
+        Http::fake([
+            'clanaod.net/forums/external.php*' => Http::response([], 500)
+        ]);
+
+        $data = $this->get(route('home'));
+
+        $data->assertOk();
+    }
 }


### PR DESCRIPTION
Exception was thrown when the iterator tried to iterate past the items available. Added test to verify a missing announcement feed doesn't break the page