### PR TITLE
Fix Pint style drift on main

### DIFF
--- a/app/Http/Controllers/SitemapController.php
+++ b/app/Http/Controllers/SitemapController.php
@@ -15,7 +15,8 @@ class SitemapController extends Controller
 
         try {
             $divisions = DivisionRepository::all()->json('data') ?? [];
-        } catch (\Exception) {}
+        } catch (\Exception) {
+        }
 
         return response()
             ->view('sitemap', compact('divisions'))

--- a/app/Repositories/AOD/Repository.php
+++ b/app/Repositories/AOD/Repository.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Repositories\AOD;
 
+use GuzzleHttp\Promise\PromiseInterface;
 use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Http\Client\Response;
 use Illuminate\Support\Facades\Http;
@@ -27,7 +28,7 @@ class Repository
     }
 
     /**
-     * @return \GuzzleHttp\Promise\PromiseInterface|\Illuminate\Http\Client\Response
+     * @return PromiseInterface|Response
      */
     protected function getPromise(string|array $url, array $params = []): Response
     {

--- a/bootstrap/providers.php
+++ b/bootstrap/providers.php
@@ -1,6 +1,9 @@
 <?php
 
+use App\Providers\AppServiceProvider;
+use App\Providers\ViewServiceProvider;
+
 return [
-    App\Providers\AppServiceProvider::class,
-    App\Providers\ViewServiceProvider::class,
+    AppServiceProvider::class,
+    ViewServiceProvider::class,
 ];

--- a/config/auth.php
+++ b/config/auth.php
@@ -1,5 +1,7 @@
 <?php
 
+use App\Models\User;
+
 return [
 
     /*
@@ -68,7 +70,7 @@ return [
     'providers' => [
         'users' => [
             'driver' => 'eloquent',
-            'model' => App\Models\User::class,
+            'model' => User::class,
         ],
 
         // 'users' => [

--- a/config/markdown.php
+++ b/config/markdown.php
@@ -11,8 +11,12 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
+use League\CommonMark\Extension\CommonMark\CommonMarkCoreExtension;
 use League\CommonMark\Extension\CommonMark\Node\Inline\Link;
+use League\CommonMark\Extension\DefaultAttributes\DefaultAttributesExtension;
 use League\CommonMark\Extension\Embed\Bridge\OscaroteroEmbedAdapter;
+use League\CommonMark\Extension\Embed\EmbedExtension;
+use League\CommonMark\Extension\Table\TableExtension;
 
 return [
 
@@ -48,12 +52,12 @@ return [
     */
 
     'extensions' => [
-        League\CommonMark\Extension\CommonMark\CommonMarkCoreExtension::class,
-        League\CommonMark\Extension\Table\TableExtension::class,
+        CommonMarkCoreExtension::class,
+        TableExtension::class,
 
         // custom extensions
-        League\CommonMark\Extension\Embed\EmbedExtension::class,
-        League\CommonMark\Extension\DefaultAttributes\DefaultAttributesExtension::class,
+        EmbedExtension::class,
+        DefaultAttributesExtension::class,
     ],
 
     /*

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,4 +1,6 @@
 <?php
 
-pest()->extend(Tests\TestCase::class)->in('Feature');
-pest()->extend(Tests\TestCase::class)->in('Unit');
+use Tests\TestCase;
+
+pest()->extend(TestCase::class)->in('Feature');
+pest()->extend(TestCase::class)->in('Unit');

--- a/tests/Unit/RepositoryTest.php
+++ b/tests/Unit/RepositoryTest.php
@@ -3,6 +3,7 @@
 use App\Repositories\AOD\DivisionRepository;
 use App\Repositories\AOD\Repository;
 use App\Repositories\AOD\SocialRepository;
+use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Support\Facades\Http;
 
 describe('AOD Repository', function () {
@@ -28,7 +29,7 @@ describe('AOD Repository', function () {
             $reflection = new ReflectionClass($repository);
             $client = $reflection->getProperty('client')->getValue($repository);
 
-            expect($client)->toBeInstanceOf(\Illuminate\Http\Client\PendingRequest::class);
+            expect($client)->toBeInstanceOf(PendingRequest::class);
         });
 
         it('builds correct API URLs', function () {


### PR DESCRIPTION
## Summary
- `main` currently has 7 files with unfixed Laravel Pint style issues, unrelated to any particular PR's diff.
- The `code-quality` CI job tries to auto-fix and push style issues on every PR run, but fails in detached HEAD on `pull_request`-triggered checkouts (`fatal: You are not currently on a branch`), which is currently blocking #164 (and would block any other PR that touches these files).
- This PR fixes the drift directly so the `code-quality` job has nothing to fix and passes cleanly.

## Test plan
- [x] `./vendor/bin/pint --test` passes
- [x] Full test suite passes (82 passed) via `sail artisan test`